### PR TITLE
Simplify Browser Rendering getting started

### DIFF
--- a/content/analytics/analytics-engine/get-started.md
+++ b/content/analytics/analytics-engine/get-started.md
@@ -8,30 +8,23 @@ meta:
 
 # Get started with Workers Analytics Engine
 
-There are four steps to get started with Workers Analytics Engine:
+Workers Analytics Engine collects custom events from your Workers and lets you query them with SQL. The fastest way to try it is to complete the following workflow.
 
-## 1. Enable Analytics Engine for your account
+## 1. Enable Analytics Engine
 
-* Log into the [Cloudflare dashboard](https://dash.cloudflare.com) and select your account.
-* Go to **Workers & Pages**.
-* In **Overview**, find **Analytics Engine** in the right side bar and select **Set up**.
-* Select **Enable Analytics Engine**
+1. Log into the [Cloudflare dashboard](https://dash.cloudflare.com) and select your account.
+2. Go to **Workers & Pages** ▸ **Overview**.
+3. In the right sidebar, find **Analytics Engine** and select **Set up** ▸ **Enable Analytics Engine**.
 
-## 2. Configure your dataset and binding in Wrangler
+## 2. Configure a dataset binding in Wrangler
 
-All data in Workers Analytics Engine is written to a dataset. A dataset is conceptually like a table in SQL: the rows and columns should have consistent meaning.
-
-To access your dataset from the Workers runtime, you need to create a binding using [Wrangler](/workers/wrangler/configuration/). A binding is like an [environment variable](/workers/configuration/environment-variables/) that you can use in the Workers runtime which enables you to write to a dataset. A dataset is created implicitly after you define your binding and begin writing to it from a Worker.
-
-In this guide, we will show you how to start using a dataset.
+Workers Analytics Engine stores data in datasets (similar to SQL tables). Create a dataset binding in [Wrangler](/workers/wrangler/configuration/) so that your Worker can write to it. The dataset is created automatically the first time you write data.
 
 {{<Aside type="note">}}
-  
-To define an Analytics Engine binding you must be using at least version 2.6.0 of [Wrangler](/workers/wrangler/install-and-update/).
-
+Use Wrangler `2.6.0` or later to define Analytics Engine bindings. You can [install or update Wrangler here](/workers/wrangler/install-and-update/).
 {{</Aside>}}
 
-Add the binding to your `wrangler.toml` file, for example:
+Add the binding to your `wrangler.toml` file:
 
 ```toml
 ---
@@ -41,13 +34,9 @@ filename: wrangler.toml
 binding = "<BINDING_NAME>"
 ```
 
-By default, the dataset name is the same as the binding name.
+By default the dataset name matches the binding name. Make sure the binding value is [a valid JavaScript identifier](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Grammar_and_types#variables); the binding is exposed inside your Worker as `env.<BINDING_NAME>` with the `writeDataPoint()` method.
 
-* The binding must be [a valid JavaScript variable name](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Grammar_and_types#variables).
-* For example, `binding = "MY_DATASET"` or `binding = "metricsDataset"` would both be valid names for the binding.
-* Your binding is available in your Worker at `env.<BINDING_NAME>` and exposes the `writeDataPoint` method.
-
-If you want, you can also specify the dataset name:
+Optionally give the dataset a different name:
 
 ```toml
 ---
@@ -58,17 +47,17 @@ binding = "<BINDING_NAME>"
 dataset = "<DATASET_NAME>"
 ```
 
-Save the changes that you made to your `wrangler.toml` file. Redeploy your Worker by running `npx wrangler deploy` from the Terminal window to update the changes. In the dashboard, you can also verify if your deployment was successful.
+Run `npx wrangler deploy` to redeploy your Worker with the new binding.
 
 ## 3. Write data from your Worker
 
-Once a binding is declared in Wrangler and your worker is deployed, you get a new environment variable in the Workers runtime that represents your Workers Analytics Engine dataset. This variable has a method, `writeDataPoint()`. A data point is a structured event which consists of a vector of blobs and a vector of doubles. Calls to `writeDataPoint` will return immediately while processing of the data point continues in the background.
+Use the binding’s `writeDataPoint()` method to send events. Each data point contains:
 
-A double is just a number type field that can be aggregated in some way – for example, it could be summed, averaged, or quantiled. A blob is a string type field that can be used for grouping or filtering. Indexes are strings that will be used as a [sampling](/analytics/analytics-engine/sql-api/#sampling) key.
+* `blobs`: string fields for grouping/filtering (for example, city or sensor ID).
+* `doubles`: numeric fields for aggregation (for example, temperature or latency).
+* `indexes`: string fields used for [sampling](/analytics/analytics-engine/sql-api/#sampling).
 
-For example, suppose you are collecting air quality samples. Each data point would represent a reading from your weather sensor. Doubles might include numbers like the temperature or air pressure reading. The blobs could include the location of the sensor and the hardware identifier of the sensor.
-
-This is how it translates into code:
+Example Worker that records sensor data:
 
 ```js
   async fetch(request, env) {
@@ -81,9 +70,7 @@ This is how it translates into code:
   }
 ```
 
-Besides writing static data points, a common use case of Workers Analytics Engine is to capture information about incoming HTTP requests.
-
-In the runtime API documentation, you can find  information about the [variables](/workers/runtime-apis/request/). Because these variables are already available in the runtime, you will not need to define them. In other words, you can directly use `request.cf.<variable name>` as a blob or double field. Using this adaptation of this Worker [example](/workers/examples/geolocation-hello-world/) template, you can write the geolocation variables to Analytics Engine.
+You can also log metadata from incoming requests by reusing existing [runtime variables](/workers/runtime-apis/request/). The following Worker (based on the [Geolocation Hello World example](/workers/examples/geolocation-hello-world/)) writes geographic information directly to Analytics Engine without redefining the fields:
 
 ```js
 env.<EXAMPLE_DATASET>.writeDataPoint({
@@ -105,19 +92,16 @@ env.<EXAMPLE_DATASET>.writeDataPoint({
 });
 ```
 
-In our initial version, developers are responsible for **providing fields in a consistent order**, so that they have the same semantics when querying. In a future iteration, we plan to let developers name their blobs and doubles in the binding, and then use these names when writing data points in the runtime.
+When writing data, keep blobs and doubles in a consistent order so you can reference them later when querying.
 
-## 4. Query data using GraphQL and SQL API
+## 4. Query data with GraphQL or SQL
 
-Data can be queried using either [GraphQL](/analytics/graphql-api/) or the [SQL API](/analytics/analytics-engine/sql-api/).
+Query Workers Analytics Engine data through:
 
-The GraphQL API powers our dashboard and is better suited for building interactive dashboards. At this time, the GraphQL API exposes a highly simplified schema, though we plan to support a richer schema over time.
+* [GraphQL](/analytics/graphql-api/) – best for powering dashboards with a simplified schema.
+* [SQL API](/analytics/analytics-engine/sql-api/) – best for ad hoc queries, ClickHouse-compatible tools, or Grafana.
 
-SQL API is better suited for writing ad hoc queries and integrating with external tools like Grafana. At this time, the SQL API only supports the `SELECT` statement and a limited subset of SQL functionality.
-
-The SQL API is available as an HTTP endpoint at `https://api.cloudflare.com/client/v4/accounts/YOUR_ACCOUNT_ID/analytics_engine/sql` using the `POST` and `GET` method. You need to include an `Authorization: Bearer _____` token where the underscores should be replaced with a Cloudflare [API Token](https://dash.cloudflare.com/profile/api-tokens) that has the `Account Analytics Read` permission.
-
-If you prefer a graphical interface, you can use [Postman](https://www.postman.com/) to connect to the SQL API endpoint and run your query. Postman is an application that can be used to test APIs. You can use the endpoint mentioned above using the `POST` and `GET` methods.
+The SQL API is an HTTP endpoint at `https://api.cloudflare.com/client/v4/accounts/YOUR_ACCOUNT_ID/analytics_engine/sql` (use `POST` or `GET`). Authenticate with a Cloudflare [API Token](https://dash.cloudflare.com/profile/api-tokens) that has the **Account Analytics Read** permission. Tools like [Postman](https://www.postman.com/) can send the request if you prefer a GUI.
 
 ### Example of querying data with the SQL API
 
@@ -136,19 +120,17 @@ ORDER BY avg_humidity DESC
 LIMIT 10
 ```
 
-You can then perform the query using any HTTP client. Here is an example of doing it using cURL:
+Execute the query with any HTTP client, for example cURL:
 
 ```curl
 curl -X POST "https://api.cloudflare.com/client/v4/accounts/YOUR_ACCOUNT_ID/analytics_engine/sql" -H "Authorization: Bearer YOUR_API_TOKEN" -d "SELECT blob1 AS city, SUM(_sample_interval * double2) / SUM(_sample_interval) AS avg_humidity FROM WEATHER WHERE double1 > 0 GROUP BY city ORDER BY avg_humidity DESC LIMIT 10"
 ```
 
-Note that, for our initial version, blobs and doubles are accessed via names that have 1-based indexing. In the future, when developers will be able to name blobs and doubles in their binding, these names will also be available via the SQL API.
-
-Refer to the [SQL API docs](/analytics/analytics-engine/sql-api/) for more information on connecting to and querying SQL API and the [Workers Analytics Engine SQL Reference](/analytics/analytics-engine/sql-reference/) for a full list of supported SQL functionality.
+Blobs and doubles currently use 1-based indexing (`blob1`, `double1`, etc.). Refer to the [SQL API docs](/analytics/analytics-engine/sql-api/) and the [SQL reference](/analytics/analytics-engine/sql-reference/) for the supported syntax.
 
 ### Working with time series
 
-Workers Analytics Engine is optimized for powering time series analytics that can be visualized using tools like Grafana. Every event written from the runtime is automatically populated with a `timestamp` field. It is expected that most time series will round, and then `GROUP BY` the `timestamp`. For example:
+Workers Analytics Engine automatically adds a `timestamp` field to every event so that you can build time series views. Most queries round and `GROUP BY` the timestamp. For example:
 
 ```sql
 SELECT
@@ -165,16 +147,16 @@ ORDER BY t, avg_humidity DESC
 
 This query first rounds the `timestamp` field to the nearest five minutes. Then, it groups by that field and city and calculates the average humidity in each city for a five minute period.
 
-Refer to [Querying Workers Analytics Engine from Grafana](/analytics/analytics-engine/grafana/) for more details on how to create efficient Grafana queries against Workers Analytics Engine.
+Refer to [Querying Workers Analytics Engine from Grafana](/analytics/analytics-engine/grafana/) for more details on creating efficient Grafana queries.
 
 ## Limits
 
 The following limits apply to Analytics Engine:
 
-* Analytics Engine will accept up to twenty blobs, twenty doubles, and one index per request.
-* The total size of all blobs in a request must not exceed 5120 bytes.
-* Each index must not be more than 96 bytes.
-* There is also a limit of 25 writes (`writeDataPoint` invocations) per client HTTP request.
+* Up to 20 blobs, 20 doubles, and 1 index per request.
+* All blobs combined must be ≤ 5120 bytes.
+* An index can be ≤ 96 bytes.
+* At most 25 `writeDataPoint()` calls per incoming HTTP request.
 
 ## Data retention
 


### PR DESCRIPTION
## Summary
- streamlined the Workers Analytics Engine getting started workflow and clarified each step
- simplified instructions for adding bindings, writing datapoints, and querying with SQL/GraphQL
- condensed limits language for quicker scanning

------
Generated by OpenCode running in the Cloudflare Editor ([view logs](https://logs.com))
[Edit this branch](https://chatgpt.com/codex/tasks/task_e_6918ca42ab988332bbdda291c77a39a1)